### PR TITLE
Fix start/end line collision

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,6 +204,9 @@ function translateViolationToComment(filePath, violation, engine) {
     ? parseInt(violation.endLine)
     : parseInt(violation.line);
   let startLine = parseInt(violation.line);
+  if (endLine == startLine) {
+    endLine++;
+  }
   return {
     commit_id: this.pullRequest?.head?.sha,
     path: filePath,


### PR DESCRIPTION
Fixes the following error when findings only span one line:

"message":"pull_request_review_thread.start_line must precede the end line."