### PR TITLE
Add "Destination" origin to allow cross repo PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
           npm install sfdx-cli
           node_modules/sfdx-cli/bin/run plugins:install @salesforce/sfdx-scanner
       - name: Run SFDX Scanner - Report findings as comments
-        uses: mitchspano/sfdx-scan-pull-request@v0.1.3
+        uses: mitchspano/sfdx-scan-pull-request@v0.1.5
         with:
           pmdconfig: ruleset.xml
           severity-threshold: 4

--- a/index.js
+++ b/index.js
@@ -89,7 +89,11 @@ function validatePullRequestContext() {
 function getDiffInPullRequest() {
   console.log("Getting difference within the pull request...");
   execSync(
-    `git diff origin/${this.pullRequest?.base?.ref}...origin/${this.pullRequest?.head?.ref} > ${DIFF_OUTPUT}`
+    `git remote add -f destination ${this.pullRequest.base.repo.clone_url}`
+  );
+  execSync(`git remote update`);
+  execSync(
+    `git diff destination/${this.pullRequest?.base?.ref}...origin/${this.pullRequest?.head?.ref} > ${DIFF_OUTPUT}`
   );
   const files = parse(fs.readFileSync(DIFF_OUTPUT).toString());
   for (let file of files) {


### PR DESCRIPTION
Enable Diffs on Fork PRs - Fixes #23

Enables the git diff to be calculated when the pull request is initiated from a forked repository by defining a new remote for the destination repository.