### PR TITLE
Prevent creating duplicate comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,7 +300,11 @@ async function writeComments() {
         const method = `POST /repos/${owner}/${repo}/pulls/${prNumber}/comments`;
         await octokit.request(method, comment);
       } else {
-        console.log('Skipping existing comment...', existingComment);
+        console.log('Skipping existing comment...', {
+          line: existingComment.line,
+          body: existingComment.body,
+          path: existingComment.path
+        });
       }
 
     }
@@ -311,7 +315,9 @@ async function writeComments() {
 }
 
 function matchComment(commentA, commentB) {
-  return commentA.line === commentB.line && commentA.body === commentB.body;
+  return commentA.line === commentB.line &&
+    commentA.body === commentB.body &&
+    commentA.path === commentB.path;
 }
 
 /**


### PR DESCRIPTION
This action is a great idea and well built, but we did have an issue when using it and anyone updated the PR it would cause a bunch of duplicates.

## Change summary:
- Get all comments on the current PR
- Check to see if we have a similar comment already before creating a new one
   - This is checked by finding the first comment that matches on the `line`, `path` and `body` of both comments

Slightly brute force approach, but this worked fine on a PR with over 100+ violations